### PR TITLE
EDGE-631 Optionally prepend XML header in WebRtcTransfer.generateBxml()

### DIFF
--- a/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
+++ b/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
@@ -7,9 +7,17 @@ public class WebRtcTransfer {
     }
 
     public static String generateBxml(String deviceToken, String sipUri) {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
-            + "<Response><Transfer>\n"
-            + "\t<SipUri uui=\"" + deviceToken + ";encoding=jwt\">" + sipUri + "</SipUri>\n"
-            + "</Transfer></Response>\n";
+        return generateBxml(deviceToken, sipUri, true);
+    }
+
+    public static String generateBxml(String deviceToken, String sipUri, boolean appendXmlHeader) {
+        StringBuilder rv = new StringBuilder();
+        if (appendXmlHeader) {
+            rv.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
+        }
+        rv.append("<Response><Transfer>\n"
+                + "\t<SipUri uui=\"" + deviceToken + ";encoding=jwt\">" + sipUri + "</SipUri>\n"
+                + "</Transfer></Response>\n");
+        return rv.toString();
     }
 }

--- a/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
+++ b/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
@@ -7,17 +7,15 @@ public class WebRtcTransfer {
     }
 
     public static String generateBxml(String deviceToken, String sipUri) {
-        return generateBxml(deviceToken, sipUri, true);
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                + "<Response>"
+                + generateTransferVerb(deviceToken, sipUri)
+                + "</Response>\n";
     }
 
-    public static String generateBxml(String deviceToken, String sipUri, boolean prependXmlHeader) {
-        StringBuilder rv = new StringBuilder();
-        if (prependXmlHeader) {
-            rv.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-        }
-        rv.append("<Response><Transfer>\n"
+    public static String generateTransferVerb(String deviceToken, String sipUri) {
+        return "<Transfer>\n"
                 + "\t<SipUri uui=\"" + deviceToken + ";encoding=jwt\">" + sipUri + "</SipUri>\n"
-                + "</Transfer></Response>\n");
-        return rv.toString();
+                + "</Transfer>";
     }
 }

--- a/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
+++ b/src/main/java/com/bandwidth/webrtc/utils/WebRtcTransfer.java
@@ -10,9 +10,9 @@ public class WebRtcTransfer {
         return generateBxml(deviceToken, sipUri, true);
     }
 
-    public static String generateBxml(String deviceToken, String sipUri, boolean appendXmlHeader) {
+    public static String generateBxml(String deviceToken, String sipUri, boolean prependXmlHeader) {
         StringBuilder rv = new StringBuilder();
-        if (appendXmlHeader) {
+        if (prependXmlHeader) {
             rv.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
         }
         rv.append("<Response><Transfer>\n"


### PR DESCRIPTION
We need to make this function more flexible in the case where users have other BXML they want to include. I'd remove the XML header altogether but that would be a breaking change. Thus I added a flag that defaults to true.