### PR TITLE
DX-2288 Fixed AnswerCall Attribute Of Ring BXML Verb

### DIFF
--- a/src/main/java/com/bandwidth/voice/bxml/verbs/Ring.java
+++ b/src/main/java/com/bandwidth/voice/bxml/verbs/Ring.java
@@ -25,5 +25,5 @@ public class Ring implements Verb {
      * incoming call. Default value is 'true'.
      */
     @XmlAttribute
-    private boolean answerCall;
+    private Boolean answerCall;
 }

--- a/src/test/java/com/bandwidth/BxmlTest.java
+++ b/src/test/java/com/bandwidth/BxmlTest.java
@@ -165,7 +165,7 @@ public class BxmlTest {
 
         assertEquals("BXML strings not equal", expected, response);
     }
-    
+
     @Test
     public void testNestedGatherSingleVerb() {
         SpeakSentence speakSentence = SpeakSentence.builder()
@@ -438,6 +438,16 @@ public class BxmlTest {
             .toBXML();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response><Ring duration=\"3.0\" answerCall=\"false\"/></Response>";
+
+        assertEquals("BXML strings not equal", expected, response);
+    }
+
+    @Test
+    public void testRingDefault() {
+        Ring ring = Ring.builder().build();
+        String response = new Response().add(ring).toBXML();
+
+        String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response><Ring/></Response>";
 
         assertEquals("BXML strings not equal", expected, response);
     }


### PR DESCRIPTION
Changed the answerCall field of the Ring class from a boolean primitive to a Boolean wrapper for a default 'null' value if not explicitly set. Otherwise, the boolean primitive would default to 'false' and the attribute would be serialized as such, even if the value wasn't set. Also added a test to assert values that aren't set aren't serialized into the BXML.