### PR TITLE
EDGE-1027 removed unnecessary participants objects from subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ publishPermissions.add(PublishPermissionEnum.VIDEO);
 ApiResponse<AccountsParticipantsResponse> createParticipantResponse = webrtcController.createParticipant(accountId, createParticipantBody);
 String participantId = createParticipantResponse.getResult().getParticipant().getId();
 
-List<ParticipantSubscription> participantSubscriptions = new ArrayList<>();
-participantSubscriptions.add(new ParticipantSubscription(participantId));
+Subscriptions subscriptions = new Subscriptions();
+subscriptions.setSessionId(sessionId);
 
-webrtcController.addParticipantToSession(accountId, sessionId, participantId, new Subscriptions(sessionId, participantSubscriptions));
+webrtcController.addParticipantToSession(accountId, sessionId, participantId, subscriptions);
 
 ```
 


### PR DESCRIPTION
The way the API works, if you only supply a session ID in the subscriptions argument, you will automatically be subscribed to all participants in a session. This makes supplying participant ids unnecessary in this case, which is why I have removed them.