### PR TITLE
Task: Update Manteca Content Type

### DIFF
--- a/src/test/java/org/openapitools/client/api/ConferencesApiTest.java
+++ b/src/test/java/org/openapitools/client/api/ConferencesApiTest.java
@@ -127,7 +127,7 @@ public class ConferencesApiTest {
                     .post(mantecaRequestBody)
                     .build();
             Call mantecaApiCall = mantecaClient.newCall(mantecaRequest);
-            testId = mantecaApiCall.execute().body().string().replace("\"", "");
+            testId = mantecaApiCall.execute().body().string();
         } catch (IOException e) {
             System.out.println(e.toString());
             throw new Exception("Failed to initialize conference tests with Manteca, aborting test run :(");

--- a/src/test/java/org/openapitools/client/api/RecordingsApiTest.java
+++ b/src/test/java/org/openapitools/client/api/RecordingsApiTest.java
@@ -126,7 +126,7 @@ public class RecordingsApiTest {
                     .post(mantecaRequestBody)
                     .build();
             Call mantecaApiCall = mantecaClient.newCall(mantecaRequest);
-            testId = mantecaApiCall.execute().body().string().replace("\"", "");
+            testId = mantecaApiCall.execute().body().string();
         } catch (IOException e) {
             System.out.println(e.toString());
             throw new Exception("Failed to initialize conference tests with Manteca, aborting test run :(");


### PR DESCRIPTION
Updating tests to account for new Manteca return type (current tests will fail until Manteca change merged).