### PR TITLE
[Bugfix][VAPI-2447]

### DIFF
--- a/src/main/java/com/bandwidth/sdk/model/CallDirectionEnum.java
+++ b/src/main/java/com/bandwidth/sdk/model/CallDirectionEnum.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * The direction of the call.
@@ -33,7 +34,7 @@ public enum CallDirectionEnum {
   
   OUTBOUND("outbound");
 
-  private String value;
+  private final String value;
 
   CallDirectionEnum(String value) {
     this.value = value;
@@ -45,7 +46,7 @@ public enum CallDirectionEnum {
 
   @Override
   public String toString() {
-    return String.valueOf(value);
+    return value;
   }
 
   public static CallDirectionEnum fromValue(String value) {
@@ -69,6 +70,24 @@ public enum CallDirectionEnum {
       return CallDirectionEnum.fromValue(value);
     }
   }
+
+  public static class XMLAdapter extends XmlAdapter<String, CallDirectionEnum> {
+    @Override
+    public CallDirectionEnum unmarshal(String v) {
+      for (CallDirectionEnum e : CallDirectionEnum.values()) {
+        if (e.toString().equals(v)) {
+          return e;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public String marshal(CallDirectionEnum v) {
+      return v.toString();
+    }
+  }
+
 
   public static void validateJsonElement(JsonElement jsonElement) throws IOException {
     String value = jsonElement.getAsString();

--- a/src/main/java/com/bandwidth/sdk/model/bxml/StartStream.java
+++ b/src/main/java/com/bandwidth/sdk/model/bxml/StartStream.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import com.bandwidth.sdk.model.CallDirectionEnum;
 
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -83,6 +84,7 @@ public class StartStream implements Verb {
     protected String mode;
 
     @XmlAttribute
+    @XmlJavaTypeAdapter(CallDirectionEnum.XMLAdapter.class)
     @Default
     protected CallDirectionEnum tracks = CallDirectionEnum.INBOUND;
 


### PR DESCRIPTION
[Bugfix][VAPI-2447] - Added XML Adapter to parse the enum as an enum string value instead of enum name

[VAPI-2447]: https://bandwidth-jira.atlassian.net/browse/VAPI-2447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ